### PR TITLE
Enabled monitoring of CF via cg-metrics

### DIFF
--- a/cf/cf-properties.yml
+++ b/cf/cf-properties.yml
@@ -45,6 +45,10 @@ properties:
 
   collector:
     deployment_name: (( meta.environment ))
+    graphite:
+      address: 10.10.101.63
+      port: 2003
+    use_graphite: true
     use_newrelic_insights: true
     newrelic_insights:
       api_key: (( merge ))


### PR DESCRIPTION
This patch enables monitoring of CF via cg-metrics.
For more information about cg-metrics please visit:
https://github.com/18F/cg-metrics
