### PR TITLE
Fix IP for cg-metrics in cf manifest

### DIFF
--- a/cf/generate-staging.sh
+++ b/cf/generate-staging.sh
@@ -11,3 +11,5 @@ spiff merge \
   > manifest-staging.yml
 
 sed -i -- 's/10.10/10.9/g' manifest-staging.yml
+# Reverts this IP back for the cg-metrics
+sed -i -- 's/10.9.101.63/10.10.101.63/g' manifest-staging.yml


### PR DESCRIPTION
This commit preserves the IP of cg-metrics when making the final
manifest
