### PR TITLE
Allow the generate*.sh scripts in CF manifest to run from anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ manifest.yml
 cf-secrets.yml
 secrets.yml
 cf-secrets-staging.yml
+manifest-staging.yml
+manifest-staging.yml--
 
 # Mac files
 .DS_Store

--- a/cf/generate-staging.sh
+++ b/cf/generate-staging.sh
@@ -1,16 +1,30 @@
 #!/bin/sh
 
-spiff merge \
-  cf-deployment.yml \
-  cf-resource-pools.yml \
-  cf-jobs.yml \
-  cf-lamb.yml \
-  cf-properties.yml \
-  cf-infrastructure-aws-staging.yml \
-  cf-secrets-staging.yml \
-  > manifest-staging.yml
+set -e -x
 
-sed -i -- 's/10.10/10.9/g' manifest-staging.yml
+SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+
+SECRETS=$SCRIPTPATH/cf-secrets-staging.yml
+MANIFEST=$SCRIPTPATH/manifest-staging.yml
+if [ ! -z "$1" ]; then
+  SECRETS=$1
+fi
+if [ ! -z "$2" ]; then
+  MANIFEST=$2
+fi
+
+spiff merge \
+  $SCRIPTPATH/cf-deployment.yml \
+  $SCRIPTPATH/cf-resource-pools.yml \
+  $SCRIPTPATH/cf-jobs.yml \
+  $SCRIPTPATH/cf-lamb.yml \
+  $SCRIPTPATH/cf-properties.yml \
+  $SCRIPTPATH/cf-infrastructure-aws-staging.yml \
+  $SECRETS \
+  > $MANIFEST
+
+sed -i -- 's/10.10/10.9/g' $MANIFEST
 # Reverts this IP back for the cg-metrics
-sed -i -- 's/10.9.101.63/10.10.101.63/g' manifest-staging.yml
-sed -i -- 's/10.9.1.7\n/10.10.1.7\n/g' manifest-staging.yml
+sed -i -- 's/10.9.101.63/10.10.101.63/g' $MANIFEST
+# Reverts this IP back for dns
+sed -i -- '/dns:/{n;s/10.9.1.7/10.10.1.7/}' $MANIFEST

--- a/cf/generate.sh
+++ b/cf/generate.sh
@@ -1,11 +1,24 @@
 #!/bin/sh
 
+set -e -x
+
+SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
+
+SECRETS=$SCRIPTPATH/cf-secrets.yml
+MANIFEST=$SCRIPTPATH/manifest.yml
+if [ ! -z "$1" ]; then
+  SECRETS=$1
+fi
+if [ ! -z "$2" ]; then
+  MANIFEST=$2
+fi
+
 spiff merge \
-  cf-deployment.yml \
-  cf-resource-pools.yml \
-  cf-jobs.yml \
-  cf-lamb.yml \
-  cf-properties.yml \
-  cf-infrastructure-aws.yml \
-  cf-secrets.yml \
-  > manifest.yml
+  $SCRIPTPATH/cf-deployment.yml \
+  $SCRIPTPATH/cf-resource-pools.yml \
+  $SCRIPTPATH/cf-jobs.yml \
+  $SCRIPTPATH/cf-lamb.yml \
+  $SCRIPTPATH/cf-properties.yml \
+  $SCRIPTPATH/cf-infrastructure-aws.yml \
+  $SECRETS \
+  > $MANIFEST


### PR DESCRIPTION
@dlapiduz @adrianwebb 
This allows us to re-use these scripts from concourse pipelines, yet keeps the existing functionality through using defaults if no args specified.
Also, fixes the dns issues surrounding staging cf manifest after doing the initial `sed` replace.
