### PR TITLE
Updates to manifest templates for upgraded CF

### DIFF
--- a/cf/cf-infrastructure-aws-staging.yml
+++ b/cf/cf-infrastructure-aws-staging.yml
@@ -11,7 +11,9 @@ meta:
     aws_secret_access_key: (( properties.template_only.aws.secret_access_key ))
     region: us-east-1
 
-  stemcell:
+  stemcell: (( merge || .meta.default_stemcell ))
+
+  default_stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: 3147
 
@@ -240,12 +242,12 @@ jobs:
     networks:
       - name: cf2
 
-  - name: loggregator_controller_z1
+  - name: loggregator_trafficcontroller_z1
     instances: 1
     networks:
       - name: cf1
 
-  - name: loggregator_controller_z2
+  - name: loggregator_trafficcontroller_z2
     instances: 0
     networks:
       - name: cf2

--- a/cf/cf-infrastructure-aws.yml
+++ b/cf/cf-infrastructure-aws.yml
@@ -11,7 +11,9 @@ meta:
     aws_secret_access_key: (( properties.template_only.aws.secret_access_key ))
     region: us-east-1
 
-  stemcell:
+  stemcell: (( merge || .meta.default_stemcell ))
+
+  default_stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: 3062
 
@@ -224,12 +226,12 @@ jobs:
     networks:
       - name: cf2
 
-  - name: loggregator_controller_z1
+  - name: loggregator_trafficcontroller_z1
     instances: 1
     networks:
       - name: cf1
 
-  - name: loggregator_controller_z2
+  - name: loggregator_trafficcontroller_z2
     instances: 1
     networks:
       - name: cf2

--- a/cf/cf-jobs.yml
+++ b/cf/cf-jobs.yml
@@ -639,6 +639,8 @@ properties:
 
   etcd:
     machines: (( jobs.etcd_z1.networks.cf1.static_ips jobs.etcd_z2.networks.cf2.static_ips ))
+    peer_require_ssl: false
+    require_ssl: false
 
   etcd_metrics_server:
     nats:

--- a/cf/cf-jobs.yml
+++ b/cf/cf-jobs.yml
@@ -2,8 +2,6 @@ empty_hash: {}
 
 networks: (( merge ))
 
-consul_servers: (( jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
-
 meta:
   environment: ~
 
@@ -15,6 +13,8 @@ meta:
   custom_release:
     name: 18f-cf
 
+  consul_servers: (( jobs.consul_z1.networks.cf1.static_ips jobs.consul_z2.networks.cf2.static_ips ))
+
   networks:
     z1:
       apps: cf1
@@ -22,11 +22,13 @@ meta:
     z2:
       apps: cf2
 
+  nfs_client_ranges:
+    - (( .networks.cf1.subnets.[0].range || nil ))
+    - (( .networks.cf2.subnets.[0].range || nil ))
+
   nfs_server:
     address: (( jobs.nfs_z1.networks.cf1.static_ips.[0] || nil ))
-    allow_from_entries:
-      - (( .networks.cf1.subnets.[0].range || nil ))
-      - (( .networks.cf2.subnets.[0].range || nil ))
+    allow_from_entries: (( merge || meta.nfs_client_ranges ))
     share: ~
     share_path: (( merge || "" ))
 
@@ -598,7 +600,7 @@ properties:
     agent:
       log_level: (( merge || nil ))
       servers:
-        lan: (( consul_servers ))
+        lan: (( meta.consul_servers ))
     ca_cert: ""
     agent_cert: ""
     agent_key: ""
@@ -664,6 +666,11 @@ properties:
     heartbeat_interval_in_seconds: 10
     rlimit_core: (( merge || 0 ))
     allow_host_access: ~
+
+  loggregator:
+    <<: (( merge ))
+    etcd:
+      machines: (( .properties.etcd.machines ))
 
   loggregator_endpoint:
     shared_secret: (( merge ))

--- a/cf/cf-jobs.yml
+++ b/cf/cf-jobs.yml
@@ -81,7 +81,7 @@ meta:
   - name: gorouter
     release: (( meta.release.name ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.consul_templates.consul_agent.release ))
 
   routing_api_templates:
   - name: routing-api
@@ -118,8 +118,10 @@ meta:
   - name: uaa
     release: (( meta.custom_release.name ))
   - name: consul_agent
-    release: (( meta.release.name ))
+    release: (( meta.consul_templates.consul_agent.release ))
   - name: route_registrar
+    release: (( meta.release.name ))
+  - name: statsd-injector
     release: (( meta.release.name ))
 
   login_templates:
@@ -146,10 +148,22 @@ meta:
   - name: metron_agent
     release: (( meta.release.name ))
 
+  loggregator_trafficcontroller_routes:
+  - name: doppler
+    port: (( .properties.loggregator.outgoing_dropsonde_port ))
+    uris:
+    - (( "doppler." .properties.domain ))
+  - name: loggregator
+    port: (( .properties.traffic_controller.outgoing_port ))
+    uris:
+    - (( "loggregator." .properties.domain ))
+
   loggregator_trafficcontroller_templates:
   - name: loggregator_trafficcontroller
     release: (( meta.release.name ))
   - name: metron_agent
+    release: (( meta.release.name ))
+  - name: route_registrar
     release: (( meta.release.name ))
 
   consul_templates:
@@ -285,10 +299,9 @@ jobs:
         zone: z1
       route_registrar:
         routes: (( merge || meta.uaa_routes ))
-      router:
-        servers:
-          z1: (( jobs.router_z1.networks.cf1.static_ips ))
-          z2: (( jobs.router_z2.networks.cf2.static_ips ))
+      uaa:
+        proxy:
+          servers: (( merge || jobs.router_z1.networks.cf1.static_ips jobs.router_z2.networks.cf2.static_ips))
     update: (( merge || empty_hash ))
 
   - name: uaa_z2
@@ -306,10 +319,9 @@ jobs:
         zone: z2
       route_registrar:
         routes: (( merge || meta.uaa_routes ))
-      router:
-        servers:
-          z1: (( jobs.router_z1.networks.cf1.static_ips ))
-          z2: (( jobs.router_z2.networks.cf2.static_ips ))
+      uaa:
+        proxy:
+          servers: (( merge || jobs.router_z1.networks.cf1.static_ips jobs.router_z2.networks.cf2.static_ips))
     update: (( merge || empty_hash ))
 
   - name: stats_z1
@@ -494,6 +506,8 @@ jobs:
         zone: z1
       traffic_controller:
         zone: z1
+      route_registrar:
+        routes: (( merge || meta.loggregator_trafficcontroller_routes ))
     update: (( merge || empty_hash ))
 
   - name: loggregator_trafficcontroller_z2
@@ -507,6 +521,8 @@ jobs:
         zone: z2
       traffic_controller:
         zone: z2
+      route_registrar:
+        routes: (( merge || meta.loggregator_trafficcontroller_routes ))
     update: (( merge || empty_hash ))
 
   - name: router_z1

--- a/cf/cf-properties.yml
+++ b/cf/cf-properties.yml
@@ -47,6 +47,7 @@ properties:
     maxRetainedLogMessages: 100
     debug: (( merge || false ))
     blacklisted_syslog_ranges: ~
+    outgoing_dropsonde_port: 8081
 
   doppler:
     maxRetainedLogMessages: 100
@@ -56,6 +57,9 @@ properties:
 
   metron_agent:
     deployment: (( meta.environment ))
+
+  traffic_controller:
+    outgoing_port: 8080
 
   collector:
     deployment_name: (( meta.environment ))

--- a/cf/cf-properties.yml
+++ b/cf/cf-properties.yml
@@ -99,6 +99,8 @@ properties:
       cutoff_age_in_days: 31
     audit_events:
       cutoff_age_in_days: 31
+    service_usage_events:
+      cutoff_age_in_days: 31
 
     users_can_select_backend: true
     default_to_diego_backend: false

--- a/cf/cf-properties.yml
+++ b/cf/cf-properties.yml
@@ -299,10 +299,6 @@ properties:
         countFailuresWithinSeconds: ~
         lockoutPeriodSeconds: ~
 
-    batch:
-      username: (( merge ))
-      password: (( merge ))
-
     login: ~
 
     ldap: ~
@@ -334,8 +330,12 @@ properties:
         authorities: scim.userids
         secret: (( merge ))
         authorized-grant-types: client_credentials
+      cc_routing:
+        authorities: routing.router_groups.read
+        secret: (( merge ))
+        authorized-grant-types: client_credentials
       gorouter:
-        authorities: clients.read,clients.write,clients.admin,route.admin,route.advertise
+        authorities: clients.read,clients.write,clients.admin,routing.routes.write,routing.routes.read
         authorized-grant-types: client_credentials,refresh_token
         scope: openid,cloud_controller_service_permissions.read
         secret: (( merge ))

--- a/cf/cf-secrets-example.yml
+++ b/cf/cf-secrets-example.yml
@@ -76,9 +76,6 @@ properties:
   uaa:
     admin:
       client_secret: RANDOM_SECRET
-    batch:
-      username: BATCH_USERNAME
-      password: RANDOM_SECRET
     cc:
       client_secret: RANDOM_SECRET
     clients:
@@ -91,6 +88,8 @@ properties:
       notifications:
         secret: RANDOM_SECRET
       doppler:
+        secret: RANDOM_SECRET
+      cc_routing:
         secret: RANDOM_SECRET
       cloud_controller_username_lookup:
         secret: RANDOM_SECRET


### PR DESCRIPTION
@dlapiduz
Notable changes:
- Can specify stemcell in secrets

```
meta:
 ...
  stemcell:
    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
    version: 3157
 ...
```
- Need to create a new random secret for `cc_routing` in `properties.uaa.clients`

```
...
properties:
...
  uaa:
  ...
    clients:
    ...
      cc_routing:
        secret: RANDOM_SECRET
```
