### PR TITLE
Patching the Concourse deployment with an updated BOSH Deployment Resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ manifest-staging.yml--
 
 # Eclipse files
 .project
+
+# Temporary directory
+tmp/

--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -159,9 +159,38 @@ jobs:
         agent:
           servers: {lan: [*discovery_static_ip]}
       groundcrew:
+        resource_types:
+          - type: archive
+            image: /var/vcap/packages/archive_resource
+          - type: cf
+            image: /var/vcap/packages/cf_resource
+          - type: docker-image
+            image: /var/vcap/packages/docker_image_resource
+          - type: git
+            image: /var/vcap/packages/git_resource
+          - type: s3
+            image: /var/vcap/packages/s3_resource
+          - type: semver
+            image: /var/vcap/packages/semver_resource
+          - type: time
+            image: /var/vcap/packages/time_resource
+          - type: tracker
+            image: /var/vcap/packages/tracker_resource
+          - type: pool
+            image: /var/vcap/packages/pool_resource
+          - type: vagrant-cloud
+            image: /var/vcap/packages/vagrant_cloud_resource
+          - type: github-release
+            image: /var/vcap/packages/github_release_resource
+          - type: bosh-io-release
+            image: /var/vcap/packages/bosh_io_release_resource
+          - type: bosh-io-stemcell
+            image: /var/vcap/packages/bosh_io_stemcell_resource
+          - type: bosh-deployment
+            image: docker://18fgsa/bosh-deployment-resource
         additional_resource_types:
-        - type: slack-notification
-          image: /var/vcap/packages/slack-notification-resource
+          - type: slack-notification
+            image: /var/vcap/packages/slack-notification-resource
 disk_pools:
   - name: database
     disk_size: (( meta.disk.database.size ))

--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -187,7 +187,7 @@ jobs:
           - type: bosh-io-stemcell
             image: /var/vcap/packages/bosh_io_stemcell_resource
           - type: bosh-deployment
-            image: docker://18fgsa/bosh-deployment-resource
+            image: docker:///18fgsa/bosh-deployment-resource
         additional_resource_types:
           - type: slack-notification
             image: /var/vcap/packages/slack-notification-resource

--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -187,7 +187,7 @@ jobs:
           - type: bosh-io-stemcell
             image: /var/vcap/packages/bosh_io_stemcell_resource
           - type: bosh-deployment
-            image: docker:///18fgsa/bosh-deployment-resource
+            image: docker:///awebb/bosh-deployment-resource
         additional_resource_types:
           - type: slack-notification
             image: /var/vcap/packages/slack-notification-resource

--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -187,7 +187,7 @@ jobs:
           - type: bosh-io-stemcell
             image: /var/vcap/packages/bosh_io_stemcell_resource
           - type: bosh-deployment
-            image: docker:///awebb/bosh-deployment-resource
+            image: docker:///18fgsa/bosh-deployment-resource
         additional_resource_types:
           - type: slack-notification
             image: /var/vcap/packages/slack-notification-resource


### PR DESCRIPTION
Overriding the Docker image for bosh deployment resource temporarily until we can get our changes synced with upstream 
