### PR TITLE
Updates to manifests required for CF V227

### DIFF
--- a/cf/cf-jobs.yml
+++ b/cf/cf-jobs.yml
@@ -645,7 +645,6 @@ properties:
   nats:
     user: (( merge ))
     password: (( merge ))
-    address: (( jobs.nats_z1.networks.cf1.static_ips.[0] ))
     port: 4222
     machines: (( jobs.nats_z1.networks.cf1.static_ips jobs.nats_z2.networks.cf2.static_ips ))
     debug: false
@@ -730,10 +729,13 @@ properties:
       user: (( merge ))
       password: (( merge ))
     secure_cookies: false
-    route_service_secrets: (( merge || nil ))
-    route_service_timeout: (( merge || nil ))
+    route_services_secret: (( merge || nil ))
+    route_services_secret_decrypt_only: (( merge || nil ))
+    route_services_timeout: (( merge || nil ))
     logrotate: (( merge || nil ))
     extra_headers_to_log: (( merge || nil ))
+    debug_addr: (( merge || nil ))
+    enable_routing_api: (( merge || nil ))
 
   secureproxy:
     listen_port: 80

--- a/cf/cf-properties.yml
+++ b/cf/cf-properties.yml
@@ -326,6 +326,14 @@ properties:
         secret: (( merge ))
         authorities: cloud_controller.admin,scim.read
         authorized-grant-types: client_credentials
+      cf:
+        id: cf
+        override: true
+        authorized-grant-types: implicit,password,refresh_token
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
+        authorities: uaa.none
+        access-token-validity: 600
+        refresh-token-validity: 2592000
       doppler:
         override: true
         authorities: uaa.resource
@@ -339,9 +347,16 @@ properties:
         secret: (( merge ))
         authorized-grant-types: client_credentials
       gorouter:
-        authorities: clients.read,clients.write,clients.admin,routing.routes.write,routing.routes.read
+        authorities: routing.routes.read
         authorized-grant-types: client_credentials,refresh_token
-        scope: openid,cloud_controller_service_permissions.read
+        secret: (( merge ))
+      tcp_emitter:
+        authorities: routing.routes.write,routing.routes.read
+        authorized-grant-types: client_credentials,refresh_token
+        secret: (( merge ))
+      tcp_router:
+        authorities: routing.routes.read
+        authorized-grant-types: client_credentials,refresh_token
         secret: (( merge ))
 
     database: ~


### PR DESCRIPTION
@dlapiduz 
This should fix deployment problems for CF staging, once secrets in S3 are updated.
- Some key names changed in router job (doesn't affect much, since defaults are `nil`)
- Changes in the UAA erb move the `cf` section from the erb to the properties manifest (https://www.pivotaltracker.com/n/projects/997278/stories/109685386) so they can be overridden.
- Restricted permissions for `gorouter` in UAA
- New OAUTH secrets required for `tcp_router` and `tcp_emitter` in UAA

Changes in secrets needed:
- Requires two new secrets for `tcp_router` and `tcp_emitter` in UAA
- Use same secret in the `acceptance_tests` for `tcp_emitter` instead of same secret used for `go_router`.
