### PR TITLE
Update to enable the resurrector plugin

### DIFF
--- a/bosh/main.yml
+++ b/bosh/main.yml
@@ -148,11 +148,16 @@ properties:
       user: admin
       password: (( merge ))
       ca_cert: (( merge ))
+      client_id: hm
+      client_secret: (( merge ))
     event_nats_enabled: false
     email_notifications: false
     tsdb_enabled: false
     pagerduty_enabled: false
     varz_enabled: true
+    resurrector_enabled: true
+    resurrector:
+      minimum_down_jobs: 3
 
   aws:
     access_key_id: (( merge ))
@@ -168,6 +173,12 @@ properties:
     <<: (( merge ))
     url: "https://10.10.1.7:8443"
     clients:
+      hm:
+        override: true
+        authorized-grant-types: client_credentials
+        scope: ""
+        authorities: bosh.admin
+        secret: (( merge )) 
       bosh_cli:
         override: true
         authorized-grant-types: password,refresh_token

--- a/bosh/secrets.example.yml
+++ b/bosh/secrets.example.yml
@@ -23,6 +23,8 @@ properties:
       name: db_user
       password: db_pass
   uaa:
+    clients:
+      hm: {secret: secret}
     scim:
       users:
       - admin|pass|scim.write,scim.read,bosh.admin
@@ -52,5 +54,6 @@ properties:
   hm:
     director_account:
       password: some_password
+      client_secret: secret
       ca_cert: |
         certs/rootCA.key


### PR DESCRIPTION
This change enables the resurrector plugin for hm as
described at https://bosh.io/docs/resurrector.html
minimum_down_jobs: 3 was set due to the relatively smaller
size of the deployment
