### PR TITLE
Enabled Cloudwatch bosh-monitor plugin to enable metrics to be pushed to

### DIFF
--- a/bosh/main.yml
+++ b/bosh/main.yml
@@ -157,6 +157,7 @@ properties:
     email_notifications: false
     tsdb_enabled: false
     pagerduty_enabled: false
+    cloud_watch_enabled: true
     varz_enabled: true
     resurrector_enabled: true
     resurrector:


### PR DESCRIPTION
CloudWatch.  This will allow us to track CPU, Disk, etc. and create alarms from
them.  https://github.com/cloudfoundry/bosh/tree/master/bosh-monitor/lib/bosh/monitor/plugins
